### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.gradle]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+[*.java]
+indent_style = tab
+insert_final_newline = false


### PR DESCRIPTION
Add ``.editorconfig`` so that users from different IDEs must use the same tab indent style.