### PR TITLE
Update license header

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/CLIPlatform.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/CLIPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/Main.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/SystemEnum.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/SystemEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/Command.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/CommandException.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/CommandException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/Parameters.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/annotations/Argument.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/annotations/Argument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/annotations/Option.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/annotations/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/annotations/Subcommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/annotations/Subcommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/console/FancyStackTrace.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/console/FancyStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/console/TableDisplay.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/console/TableDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/internal/ArgumentInfo.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/internal/ArgumentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/api/internal/OptionInfo.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/api/internal/OptionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/BuildCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/BuildCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/DownloadCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/DownloadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/InfoCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/InfoCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/InstallCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/InstallCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/MultipacksCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/MultipacksCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/SearchCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/SearchCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/UninstallCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/UninstallCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/management/DeleteCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/management/DeleteCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/management/RemoteCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/management/RemoteCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/main/java/multipacks/cli/commands/management/UploadCommand.java
+++ b/multipacks-cli/src/main/java/multipacks/cli/commands/management/UploadCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/test/java/multipacks/cli/api/tests/CommandTest.java
+++ b/multipacks-cli/src/test/java/multipacks/cli/api/tests/CommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/test/java/multipacks/cli/api/tests/sample/CommandRoot.java
+++ b/multipacks-cli/src/test/java/multipacks/cli/api/tests/sample/CommandRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-cli/src/test/java/multipacks/cli/api/tests/sample/SubcommandCommand.java
+++ b/multipacks-cli/src/test/java/multipacks/cli/api/tests/sample/SubcommandCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/authentication/CanLogin.java
+++ b/multipacks-engine/src/main/java/multipacks/authentication/CanLogin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/bundling/BundleResult.java
+++ b/multipacks-engine/src/main/java/multipacks/bundling/BundleResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/bundling/Bundler.java
+++ b/multipacks-engine/src/main/java/multipacks/bundling/Bundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/logging/Logger.java
+++ b/multipacks-engine/src/main/java/multipacks/logging/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/logging/LoggerAccess.java
+++ b/multipacks-engine/src/main/java/multipacks/logging/LoggerAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/logging/LoggingLevel.java
+++ b/multipacks-engine/src/main/java/multipacks/logging/LoggingLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/logging/LoggingStage.java
+++ b/multipacks-engine/src/main/java/multipacks/logging/LoggingStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/logging/SimpleLogger.java
+++ b/multipacks-engine/src/main/java/multipacks/logging/SimpleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/logging/legacy/AbstractLogger.java
+++ b/multipacks-engine/src/main/java/multipacks/logging/legacy/AbstractLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/logging/legacy/SystemLogger.java
+++ b/multipacks-engine/src/main/java/multipacks/logging/legacy/SystemLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/Modifier.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/Modifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/ModifiersAccess.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/ModifiersAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/BuiltinModifierBase.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/BuiltinModifierBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/Atlas.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/Atlas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/AtlasesModifier.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/AtlasesModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/AtlasSource.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/AtlasSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/DirectorySource.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/DirectorySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/FilterSource.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/FilterSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/PermutationsSource.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/PermutationsSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/SingleSource.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/atlases/sources/SingleSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/glyphs/FontInfo.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/glyphs/FontInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/glyphs/Glyph.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/glyphs/Glyph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/glyphs/GlyphsAllocation.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/glyphs/GlyphsAllocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/glyphs/GlyphsModifier.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/glyphs/GlyphsModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/models/ItemModels.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/models/ItemModels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/models/Model.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/models/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/models/ModelsModifier.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/models/ModelsModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/slices/Part.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/slices/Part.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/slices/Region.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/slices/Region.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/slices/SlicesModifier.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/slices/SlicesModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/modifier/builtin/slices/Template.java
+++ b/multipacks-engine/src/main/java/multipacks/modifier/builtin/slices/Template.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/packs/LocalPack.java
+++ b/multipacks-engine/src/main/java/multipacks/packs/LocalPack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/packs/Pack.java
+++ b/multipacks-engine/src/main/java/multipacks/packs/Pack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/packs/meta/PackIdentifier.java
+++ b/multipacks-engine/src/main/java/multipacks/packs/meta/PackIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/packs/meta/PackIndex.java
+++ b/multipacks-engine/src/main/java/multipacks/packs/meta/PackIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/packs/meta/PackInfo.java
+++ b/multipacks-engine/src/main/java/multipacks/packs/meta/PackInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/platform/Platform.java
+++ b/multipacks-engine/src/main/java/multipacks/platform/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/platform/PlatformConfig.java
+++ b/multipacks-engine/src/main/java/multipacks/platform/PlatformConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/plugins/InternalSystemPlugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/InternalSystemPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/plugins/Plugin.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/Plugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/plugins/PluginIndex.java
+++ b/multipacks-engine/src/main/java/multipacks/plugins/PluginIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/AuthorizedRepository.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/AuthorizedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/LocalRepository.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/LocalRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/RepositoriesAccess.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/RepositoriesAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/Repository.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/SimpleRepository.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/SimpleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/query/PackMultipleQueries.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/query/PackMultipleQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/query/PackNameQuery.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/query/PackNameQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/query/PackQuery.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/query/PackQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/repository/query/PackVersionQuery.java
+++ b/multipacks-engine/src/main/java/multipacks/repository/query/PackVersionQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/Blob.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/Blob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/Constants.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/Holder.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/Holder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/Messages.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/PlatformAPI.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/PlatformAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/ResourcePath.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/ResourcePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/Selects.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/Selects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/StringUtils.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/TemplatedString.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/TemplatedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/io/Deserializer.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/io/Deserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/io/IOUtils.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/io/IOUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/utils/iter/EmptyIterator.java
+++ b/multipacks-engine/src/main/java/multipacks/utils/iter/EmptyIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/versioning/GameVersions.java
+++ b/multipacks-engine/src/main/java/multipacks/versioning/GameVersions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/versioning/Version.java
+++ b/multipacks-engine/src/main/java/multipacks/versioning/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/versioning/VersionPrefix.java
+++ b/multipacks-engine/src/main/java/multipacks/versioning/VersionPrefix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/vfs/Path.java
+++ b/multipacks-engine/src/main/java/multipacks/vfs/Path.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/vfs/Vfs.java
+++ b/multipacks-engine/src/main/java/multipacks/vfs/Vfs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/vfs/VfsOutputStream.java
+++ b/multipacks-engine/src/main/java/multipacks/vfs/VfsOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/main/java/multipacks/vfs/legacy/VirtualFs.java
+++ b/multipacks-engine/src/main/java/multipacks/vfs/legacy/VirtualFs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/test/java/multipacks/tests/TestPlatform.java
+++ b/multipacks-engine/src/test/java/multipacks/tests/TestPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/test/java/multipacks/tests/TestUtils.java
+++ b/multipacks-engine/src/test/java/multipacks/tests/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/test/java/multipacks/tests/modifiers/ModifiersTest.java
+++ b/multipacks-engine/src/test/java/multipacks/tests/modifiers/ModifiersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/test/java/multipacks/tests/packs/PacksTest.java
+++ b/multipacks-engine/src/test/java/multipacks/tests/packs/PacksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/test/java/multipacks/tests/packs/RepositoriesTest.java
+++ b/multipacks-engine/src/test/java/multipacks/tests/packs/RepositoriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-engine/src/test/java/multipacks/tests/vfs/VfsTest.java
+++ b/multipacks-engine/src/test/java/multipacks/tests/vfs/VfsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-sample-plugin/src/main/java/multipacks/sampleplugin/SamplePlugin.java
+++ b/multipacks-sample-plugin/src/main/java/multipacks/sampleplugin/SamplePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/MultipacksSpigot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-spigot/src/main/java/multipacks/spigot/helpers/GlyphHelper.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/helpers/GlyphHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-spigot/src/main/java/multipacks/spigot/helpers/ModelHelper.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/helpers/ModelHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-spigot/src/main/java/multipacks/spigot/platform/SpigotLogger.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/platform/SpigotLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-spigot/src/main/java/multipacks/spigot/platform/SpigotPlatform.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/platform/SpigotPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/multipacks-spigot/src/main/java/multipacks/spigot/platform/SpigotPlatformConfig.java
+++ b/multipacks-spigot/src/main/java/multipacks/spigot/platform/SpigotPlatformConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 MangoPlex
+ * Copyright (c) 2022-2023 PhoMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Changed MangoPlex to PhoMC
  + This repository was transfered from MangoPlex to PhoMC
- Changed year number from ``2020-2022`` to ``2022-2023``